### PR TITLE
REGD-132 fix dark mode and summary table

### DIFF
--- a/components/body-map.js
+++ b/components/body-map.js
@@ -149,9 +149,6 @@ export function BodyMap({
                   const borderStyle = isSelected
                     ? "border-solid border-2 border-brand"
                     : "";
-                  const textColor = isDisabled
-                    ? "text-button-selected-disabled"
-                    : "";
                   const highlight = isHighlighted ? "bg-highlight" : "";
                   return (
                     <li key={`${organ}-bodymap-organlist`}>
@@ -159,7 +156,7 @@ export function BodyMap({
                         id={organ}
                         role="button"
                         disabled={isDisabled}
-                        className={`${textColor} ${highlight} ${borderStyle}`}
+                        className={`disabled:text-button-selected-disabled ${highlight} ${borderStyle}`}
                         tabIndex="0"
                         onClick={(e) =>
                           handleClickOrgan(
@@ -199,9 +196,6 @@ export function BodyMap({
                   const borderStyle = isSelected
                     ? "border-solid border-2 border-brand"
                     : "";
-                  const textColor = isDisabled
-                    ? "text-button-selected-disabled"
-                    : "";
                   const highlight = isHighlighted ? "bg-highlight" : "";
 
                   return (
@@ -220,7 +214,7 @@ export function BodyMap({
                         }
                         onMouseEnter={(e) => highlightOrgans(e.target.id)}
                         onMouseLeave={() => highlightOrgans()}
-                        className={`${textColor} ${highlight} ${borderStyle}`}
+                        className={`disabled:text-button-selected-disabled ${highlight} ${borderStyle}`}
                       >
                         {cell}
                       </button>

--- a/components/body-map.js
+++ b/components/body-map.js
@@ -150,7 +150,7 @@ export function BodyMap({
                     ? "border-solid border-2 border-brand"
                     : "";
                   const textColor = isDisabled ? "text-slate-400" : "";
-                  const highlight = isHighlighted ? "bg-green-200" : "";
+                  const highlight = isHighlighted ? "bg-highlight" : "";
                   return (
                     <li key={`${organ}-bodymap-organlist`}>
                       <button
@@ -198,7 +198,7 @@ export function BodyMap({
                     ? "border-solid border-2 border-brand"
                     : "";
                   const textColor = isDisabled ? "text-slate-400" : "";
-                  const highlight = isHighlighted ? "bg-green-200" : "";
+                  const highlight = isHighlighted ? "bg-highlight" : "";
 
                   return (
                     <li key={`${cell}-bodymap-cellslist`}>

--- a/components/body-map.js
+++ b/components/body-map.js
@@ -149,7 +149,9 @@ export function BodyMap({
                   const borderStyle = isSelected
                     ? "border-solid border-2 border-brand"
                     : "";
-                  const textColor = isDisabled ? "text-slate-400" : "";
+                  const textColor = isDisabled
+                    ? "text-button-selected-disabled"
+                    : "";
                   const highlight = isHighlighted ? "bg-highlight" : "";
                   return (
                     <li key={`${organ}-bodymap-organlist`}>
@@ -197,7 +199,9 @@ export function BodyMap({
                   const borderStyle = isSelected
                     ? "border-solid border-2 border-brand"
                     : "";
-                  const textColor = isDisabled ? "text-slate-400" : "";
+                  const textColor = isDisabled
+                    ? "text-button-selected-disabled"
+                    : "";
                   const highlight = isHighlighted ? "bg-highlight" : "";
 
                   return (

--- a/components/chromatin-biosample-facets.js
+++ b/components/chromatin-biosample-facets.js
@@ -24,7 +24,7 @@ export default function ChromatinBiosampleFacets({
         <div>Filter by biosample </div>
       </div>
       <div className="text-data-label text-sm italic">Grouped by organs</div>
-      <div className="overflow-y-auto h-80 bg-gradient-to-t from-gray-100 to-white border-2 border-black">
+      <div className="overflow-y-auto h-80 border-2 border-black">
         {facets.map((facet) => {
           const key = facet.biosample.replace(/[^\w\s]/gi, "").toLowerCase();
           const isSelected = biosampleFilters.includes(facet.biosample);
@@ -33,9 +33,8 @@ export default function ChromatinBiosampleFacets({
               <div className="grid grid-cols-4 ">
                 <div className="col-span-3">
                   <button
-                    className={` flex text-sm hover:bg-slate-100 gap-1 ${
-                      isSelected && "border-solid border-2 border-brand"
-                    }`}
+                    className={` flex text-sm hover:bg-highlight gap-1
+                    ${isSelected && "border-solid border-2 border-brand"}`}
                     onClick={() => handleClickBiosample(facet.biosample)}
                   >
                     <div>{facet.biosample}</div>

--- a/components/chromatin-state-facets.js
+++ b/components/chromatin-state-facets.js
@@ -31,7 +31,7 @@ export default function ChromatinStateFacets({
           return (
             <div key={key} className="flex items-center justify-between">
               <button
-                className={`flex-grow hover:bg-slate-100 ${
+                className={`flex-grow hover:bg-highlight ${
                   isSelected && "border-solid border-2 border-brand"
                 }`}
                 onClick={() => handleClickState(d)}

--- a/components/genome-browser.js
+++ b/components/genome-browser.js
@@ -334,7 +334,7 @@ export default function GenomeBrowser({ files, assembly, coordinates }) {
     return (
       <button className="reset-browser-button">
         <ArrowUturnLeftIcon className="h-5" />
-        <span className="reset-title">Reset to query variant label</span>
+        <span>Reset to query variant label</span>
       </button>
     );
   }
@@ -397,7 +397,7 @@ export default function GenomeBrowser({ files, assembly, coordinates }) {
             onClick={() => visualizer.setLocation({ contig: chr, x0, x1 })}
           >
             <ArrowUturnLeftIcon className="h-5 px-2" />
-            <span className="reset-title">Reset to query variant</span>
+            <span>Reset to query variant</span>
           </button>
         );
       }

--- a/components/motifs-view.js
+++ b/components/motifs-view.js
@@ -112,7 +112,7 @@ export function MotifElement({
         {footprintsLength > 0 && (
           <div className="grid grid-cols-3 gap-4">
             <DataItemLabel>{footprintsLabel}</DataItemLabel>
-            <div className="overflow-y-auto rounded-md  h-40 bg-gradient-to-t from-gray-100 to-white  text-data-label border-solid border-2	">
+            <div className="overflow-y-auto rounded-md  h-40  text-data-label border-solid border-2	">
               {footprintKeysSorted.map((d) => (
                 <div className="ml-2" key={d}>
                   <a

--- a/pages/summary.js
+++ b/pages/summary.js
@@ -15,7 +15,7 @@ export default function Summary({ data, queryString }) {
   const total = data.total || 0;
   const variants = [];
   const assembly = data.assembly;
-  if (total > 1) {
+  if (total >= 1) {
     for (let i = 0; i < data.variants.length; i++) {
       const variant = {};
       variant.chrom_location = `${data.variants[i].chrom}:${data.variants[i].start}-${data.variants[i].end}`;
@@ -34,7 +34,7 @@ export default function Summary({ data, queryString }) {
       <PagePreamble />
       <DataPanel>
         <DataAreaTitle>This search has found {total} variant(s).</DataAreaTitle>
-        {total > 1 && (
+        {total >= 1 && (
           <>
             <div className="flex justify-end gap-1 mb-1">
               <ButtonLink

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -107,6 +107,7 @@
     left: 20px;
     text-align: left;
     background-color: #f2f2f2;
+    color: #364565;
     border: 1px solid #bfbfbf;
     padding: 7px 20px;
     height: 50px;


### PR DESCRIPTION
1. A bug is fixed in GDS so the summary endpoint will not redirect to search endpoint if there is error in query. So for regulome UI, the summary table should be shown even if there is only one variant returned.
2. Remove the unnecessary style and use the style defined in config and global css to make sure the dark mode is working and the style is consistent. 
