### PR TITLE
REGD-154-catalog

### DIFF
--- a/components/variant-ld-table.js
+++ b/components/variant-ld-table.js
@@ -1,0 +1,56 @@
+// node_modules
+import PropTypes from "prop-types";
+import Link from "next/link";
+// components
+import { DataGridContainer } from "./data-grid";
+import SortableGrid from "./sortable-grid";
+
+const variantLDColumns = [
+  {
+    id: "location",
+    title: "Location",
+    display: ({ source }) => {
+      const url = `/search?regions=${source.location}&genome=${source.assembly}`;
+      return <Link href={url}>{source.location}</Link>;
+    },
+  },
+  {
+    id: "rsid",
+    title: "rsID",
+  },
+  {
+    id: "ref",
+    title: "Ref",
+  },
+  {
+    id: "alt",
+    title: "Alt",
+  },
+  {
+    id: "ancestry",
+    title: "Ancestry",
+  },
+  {
+    id: "r2",
+    title: "r2",
+  },
+  {
+    id: "query_spdi",
+    title: "Query SPDI",
+  },
+];
+
+/**
+ * Display a sortable table of the given data.
+ */ export default function VariantLDTable({ data }) {
+  return (
+    <DataGridContainer>
+      <SortableGrid data={data} columns={variantLDColumns} />
+    </DataGridContainer>
+  );
+}
+
+VariantLDTable.propTypes = {
+  // data to display
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/components/variant-ld-table.js
+++ b/components/variant-ld-table.js
@@ -17,6 +17,7 @@ const variantLDColumns = [
   {
     id: "rsid",
     title: "rsID",
+    display: ({ source }) => `${source.rsid.join(", ")}`,
   },
   {
     id: "ref",
@@ -35,8 +36,12 @@ const variantLDColumns = [
     title: "r2",
   },
   {
-    id: "query_spdi",
-    title: "Query SPDI",
+    id: "rank",
+    title: "Rank",
+  },
+  {
+    id: "score",
+    title: "Score",
   },
 ];
 

--- a/components/variant-ld-table.js
+++ b/components/variant-ld-table.js
@@ -5,6 +5,10 @@ import Link from "next/link";
 import { DataGridContainer } from "./data-grid";
 import SortableGrid from "./sortable-grid";
 
+const initialSort = {
+  columnId: "rank",
+};
+
 const variantLDColumns = [
   {
     id: "location",
@@ -50,7 +54,11 @@ const variantLDColumns = [
  */ export default function VariantLDTable({ data }) {
   return (
     <DataGridContainer>
-      <SortableGrid data={data} columns={variantLDColumns} />
+      <SortableGrid
+        data={data}
+        columns={variantLDColumns}
+        initialSort={initialSort}
+      />
     </DataGridContainer>
   );
 }

--- a/lib/fetch_variant_ld.js
+++ b/lib/fetch_variant_ld.js
@@ -1,10 +1,9 @@
-import _ from "lodash";
-
 const API_VARIANT = "https://api-dev.catalog.igvf.org/api/variants?";
 const API_VARIANT_LD =
   "https://api-dev.catalog.igvf.org/api/variants/variant_ld?";
 const R2 = "0.8";
 const API_SCORE = "https://gds-for-regulome-demo.demo.regulomedb.org/summary?";
+const ERRORS = ["BAD_REQUEST", "NETWORK"];
 
 /**
  * Return a list of variants in variant ld data.
@@ -25,15 +24,21 @@ export default async function fetchVariantLD(
   if (assembly === "GRCh38") {
     const regionForCatalog = getRegionForCatalog(region);
     const variants = await getVariantsByRegion(request, regionForCatalog);
-    const variantLD = await Promise.all(
-      _.map(variants, async (variant) => {
+    if (ERRORS.includes(variants.code)) {
+      return variants;
+    }
+    let variantLD = await Promise.all(
+      variants.map(async (variant) => {
         const data = await getVariantsInVariantLD(
           request,
           variant._id,
           r2,
           ancestry
         );
-        const dataFormatted = _.map(data, (pair) => {
+        if (ERRORS.includes(data.code)) {
+          return data;
+        }
+        const dataFormatted = data.map((pair) => {
           const start = pair["sequence variant"][0].pos;
           const end = (parseInt(start) + 1).toString();
           return {
@@ -47,20 +52,25 @@ export default async function fetchVariantLD(
             assembly,
           };
         });
-
         return dataFormatted;
       })
     );
-    const scores = await getVariantsScore(request, variantLD.flat(), assembly);
-    const variantsWithScore = variantLD.flat().map((variant) => ({
-      ...variant,
-      score: scores[variant.location].regulome_score.probability,
-      rank: scores[variant.location].regulome_score.ranking,
-      tissue_specific_scores:
-        scores[variant.location].regulome_score.tissue_specific_scores,
-    }));
-
-    return variantsWithScore;
+    variantLD = variantLD.flat();
+    if (variantLD.length > 0) {
+      if (ERRORS.includes(variantLD[0]?.code)) {
+        return variantLD[0];
+      }
+      const scores = await getVariantsScore(request, variantLD, assembly);
+      const variantsWithScore = variantLD.map((variant) => ({
+        ...variant,
+        score: scores[variant.location].regulome_score.probability,
+        rank: scores[variant.location].regulome_score.ranking,
+        tissue_specific_scores:
+          scores[variant.location].regulome_score.tissue_specific_scores,
+      }));
+      return variantsWithScore;
+    }
+    return [];
   }
   return [];
 }
@@ -78,6 +88,9 @@ async function getVariantsByRegion(request, region) {
   do {
     const query = `${API_VARIANT}region=${region}&page=${pageNum}`;
     variants = await request.getObjectByUrl(query);
+    if (ERRORS.includes(variants.code)) {
+      return variants;
+    }
     total = total.concat(variants);
     pageNum += 1;
   } while (variants.length === 25);
@@ -102,6 +115,9 @@ async function getVariantsInVariantLD(request, id, r2, ancestry) {
       r2 >= R2 ? r2 : R2
     }&page=${pageNum}${ancestryParam}`;
     variants = await request.getObjectByUrl(query);
+    if (ERRORS.includes(variants.code)) {
+      return variants;
+    }
     total = total.concat(variants);
     pageNum += 1;
   } while (variants.length === 25);
@@ -145,7 +161,7 @@ async function getVariantsScore(request, variants, assembly) {
 }
 
 /**
- * This function convert the region used in GDS to region used in vatalog
+ * This function convert the region used in GDS to region used in catalog
  * @param {*} region used in GDS
  * @returns region used in catalog
  */

--- a/lib/fetch_variant_ld.js
+++ b/lib/fetch_variant_ld.js
@@ -1,30 +1,40 @@
 import _ from "lodash";
 
-const API_VARIANT = "https://api.catalog.igvf.org/api/variants?";
-const API_VARIANT_LD = "https://api.catalog.igvf.org/api/variants/variant_ld?";
-const R2 = "gte:0.8";
+const API_VARIANT = "https://api-dev.catalog.igvf.org/api/variants?";
+const API_VARIANT_LD =
+  "https://api-dev.catalog.igvf.org/api/variants/variant_ld?";
+const R2 = "0.8";
+const API_SCORE = "https://gds-for-regulome-demo.demo.regulomedb.org/summary?";
 
 /**
  * Return a list of variant ld data.
  * @param {object} request to fetch data for data matrix
  * @param {string} region region for query
  * @param {string} assembly assembly for query
+ * @param {string} r2 r2 value for query
  * @returns Return a list of variants.
  */
-export default async function fetchVariantLD(request, region, assembly) {
-  const regionForCatalog = getRegionForCatalog(region);
-  const variants = await getVariantsByRegion(request, regionForCatalog);
+export default async function fetchVariantLD(
+  request,
+  region,
+  assembly,
+  r2,
+  ancestry
+) {
   if (assembly === "GRCh38") {
+    const regionForCatalog = getRegionForCatalog(region);
+    const variants = await getVariantsByRegion(request, regionForCatalog);
     const variantLD = await Promise.all(
       _.map(variants, async (variant) => {
         const id = variant._id;
-        const query = `${API_VARIANT_LD}variant_id=${id}&verbose=true&r2=${R2}`;
-        console.log(query);
+        const ancestryParam = ancestry ? `ancestry=${ancestry}` : "";
+        const query = `${API_VARIANT_LD}variant_id=${id}&verbose=true&r2=gte:${
+          r2 >= R2 ? r2 : R2
+        }&${ancestryParam}`;
         const data = await request.getObjectByUrl(query);
-        const dataFormatted = _.map(data, (pair) => {
+        const dataFormatted = await _.map(data, (pair) => {
           const start = pair["sequence variant"][0].pos;
           const end = (parseInt(start) + 1).toString();
-
           return {
             ancestry: pair.ancestry,
             r2: pair.r2,
@@ -40,8 +50,16 @@ export default async function fetchVariantLD(request, region, assembly) {
         return dataFormatted;
       })
     );
-    console.log(variantLD.flat());
-    return variantLD.flat();
+    const scores = await getVariantsScore(request, variantLD.flat(), assembly);
+    const variatnsWithScore = variantLD.flat().map((variant) => ({
+      ...variant,
+      score: scores[variant.location].regulome_score.probability,
+      rank: scores[variant.location].regulome_score.ranking,
+      tissue_specific_scores:
+        scores[variant.location].regulome_score.tissue_specific_scores,
+    }));
+
+    return variatnsWithScore;
   }
   return [];
 }
@@ -59,6 +77,21 @@ async function getVariantsByRegion(request, region) {
   return total;
 }
 
+async function getVariantsScore(request, variants, assembly) {
+  const regions = variants.reduce((acc, cur) => {
+    acc.push(cur.location);
+    return acc;
+  }, []);
+  const regionsParm = regions.join(" ");
+  const query = `${API_SCORE}regions=${regionsParm}&genome=${assembly}`;
+  const scores = await request.getObjectByUrl(query);
+  const scoresFormatted = scores.variants.reduce((acc, cur) => {
+    acc[`${cur.chrom}:${cur.start}-${cur.end}`] = cur;
+    return acc;
+  }, {});
+
+  return scoresFormatted;
+}
 function getRegionForCatalog(region) {
   const tokens = region.split("-");
   const end = (parseInt(tokens[1]) - 1).toString();

--- a/lib/fetch_variant_ld.js
+++ b/lib/fetch_variant_ld.js
@@ -1,0 +1,67 @@
+import _ from "lodash";
+
+const API_VARIANT = "https://api.catalog.igvf.org/api/variants?";
+const API_VARIANT_LD = "https://api.catalog.igvf.org/api/variants/variant_ld?";
+const R2 = "gte:0.8";
+
+/**
+ * Return a list of variant ld data.
+ * @param {object} request to fetch data for data matrix
+ * @param {string} region region for query
+ * @param {string} assembly assembly for query
+ * @returns Return a list of variants.
+ */
+export default async function fetchVariantLD(request, region, assembly) {
+  const regionForCatalog = getRegionForCatalog(region);
+  const variants = await getVariantsByRegion(request, regionForCatalog);
+  if (assembly === "GRCh38") {
+    const variantLD = await Promise.all(
+      _.map(variants, async (variant) => {
+        const id = variant._id;
+        const query = `${API_VARIANT_LD}variant_id=${id}&verbose=true&r2=${R2}`;
+        console.log(query);
+        const data = await request.getObjectByUrl(query);
+        const dataFormatted = _.map(data, (pair) => {
+          const start = pair["sequence variant"][0].pos;
+          const end = (parseInt(start) + 1).toString();
+
+          return {
+            ancestry: pair.ancestry,
+            r2: pair.r2,
+            query_spdi: variant.spdi,
+            rsid: pair["sequence variant"][0].rsid,
+            location: `${pair["sequence variant"][0].chr}:${start}-${end}`,
+            ref: pair["sequence variant"][0].ref,
+            alt: pair["sequence variant"][0].alt,
+            assembly,
+          };
+        });
+
+        return dataFormatted;
+      })
+    );
+    console.log(variantLD.flat());
+    return variantLD.flat();
+  }
+  return [];
+}
+
+async function getVariantsByRegion(request, region) {
+  let pageNum = 0;
+  let variants = [];
+  let total = [];
+  do {
+    const query = `${API_VARIANT}region=${region}&page=${pageNum}`;
+    variants = await request.getObjectByUrl(query);
+    total = total.concat(variants);
+    pageNum += 1;
+  } while (variants.length === 25);
+  return total;
+}
+
+function getRegionForCatalog(region) {
+  const tokens = region.split("-");
+  const end = (parseInt(tokens[1]) - 1).toString();
+  const regionCatalog = `${tokens[0]}-${end}`;
+  return regionCatalog;
+}

--- a/lib/fetch_variant_ld.js
+++ b/lib/fetch_variant_ld.js
@@ -7,11 +7,11 @@ const R2 = "0.8";
 const API_SCORE = "https://gds-for-regulome-demo.demo.regulomedb.org/summary?";
 
 /**
- * Return a list of variant ld data.
+ * Return a list of variants in variant ld data.
  * @param {object} request to fetch data for data matrix
- * @param {string} region region for query
- * @param {string} assembly assembly for query
- * @param {string} r2 r2 value for query
+ * @param {string} region for query
+ * @param {string} assembly for query
+ * @param {string} r2 for query
  * @returns Return a list of variants.
  */
 export default async function fetchVariantLD(
@@ -21,18 +21,19 @@ export default async function fetchVariantLD(
   r2,
   ancestry
 ) {
+  // right now we only have data for assembly GRCh38
   if (assembly === "GRCh38") {
     const regionForCatalog = getRegionForCatalog(region);
     const variants = await getVariantsByRegion(request, regionForCatalog);
     const variantLD = await Promise.all(
       _.map(variants, async (variant) => {
-        const id = variant._id;
-        const ancestryParam = ancestry ? `ancestry=${ancestry}` : "";
-        const query = `${API_VARIANT_LD}variant_id=${id}&verbose=true&r2=gte:${
-          r2 >= R2 ? r2 : R2
-        }&${ancestryParam}`;
-        const data = await request.getObjectByUrl(query);
-        const dataFormatted = await _.map(data, (pair) => {
+        const data = await getVariantsInVariantLD(
+          request,
+          variant._id,
+          r2,
+          ancestry
+        );
+        const dataFormatted = _.map(data, (pair) => {
           const start = pair["sequence variant"][0].pos;
           const end = (parseInt(start) + 1).toString();
           return {
@@ -51,7 +52,7 @@ export default async function fetchVariantLD(
       })
     );
     const scores = await getVariantsScore(request, variantLD.flat(), assembly);
-    const variatnsWithScore = variantLD.flat().map((variant) => ({
+    const variantsWithScore = variantLD.flat().map((variant) => ({
       ...variant,
       score: scores[variant.location].regulome_score.probability,
       rank: scores[variant.location].regulome_score.ranking,
@@ -59,11 +60,17 @@ export default async function fetchVariantLD(
         scores[variant.location].regulome_score.tissue_specific_scores,
     }));
 
-    return variatnsWithScore;
+    return variantsWithScore;
   }
   return [];
 }
 
+/**
+ * This function get all the variants for given region in catalog database
+ * @param {object} request to fetch data
+ * @param {string} region for query
+ * @returns all the variants for given region in catalog database
+ */
 async function getVariantsByRegion(request, region) {
   let pageNum = 0;
   let variants = [];
@@ -74,14 +81,50 @@ async function getVariantsByRegion(request, region) {
     total = total.concat(variants);
     pageNum += 1;
   } while (variants.length === 25);
-  return total;
+  return total.filter(
+    (variant) => variant.ref.length === 1 && variant.alt.length === 1
+  );
 }
 
+/**
+ * This function get all the variants for given region in catalog database
+ * @param {object} request to fetch data
+ * @param {string} region for query
+ * @returns all the variants for given region in catalog database
+ */
+async function getVariantsInVariantLD(request, id, r2, ancestry) {
+  let pageNum = 0;
+  let variants = [];
+  let total = [];
+  const ancestryParam = ancestry ? `&ancestry=${ancestry}` : "";
+  do {
+    const query = `${API_VARIANT_LD}variant_id=${id}&verbose=true&r2=gte:${
+      r2 >= R2 ? r2 : R2
+    }&page=${pageNum}${ancestryParam}`;
+    variants = await request.getObjectByUrl(query);
+    total = total.concat(variants);
+    pageNum += 1;
+  } while (variants.length === 25);
+  return total.filter(
+    (pair) =>
+      pair["sequence variant"][0].ref.length === 1 &&
+      pair["sequence variant"][0].alt.length === 1
+  );
+}
+
+/**
+ * This function query GDS to get score for each variant
+ * @param {object} request to fetch data
+ * @param {*} variants for query vairant score
+ * @param {*} assembly for query
+ * @returns a list of score for each variant
+ */
 async function getVariantsScore(request, variants, assembly) {
-  const regions = variants.reduce((acc, cur) => {
-    acc.push(cur.location);
+  const regionsSet = variants.reduce((acc, cur) => {
+    acc.add(cur.location);
     return acc;
-  }, []);
+  }, new Set());
+  const regions = Array.from(regionsSet);
   const regionsParm = regions.join(" ");
   const query = `${API_SCORE}regions=${regionsParm}&genome=${assembly}`;
   const scores = await request.getObjectByUrl(query);
@@ -92,6 +135,12 @@ async function getVariantsScore(request, variants, assembly) {
 
   return scoresFormatted;
 }
+
+/**
+ * This function convert the region used in GDS to region used in vatalog
+ * @param {*} region used in GDS
+ * @returns region used in catalog
+ */
 function getRegionForCatalog(region) {
   const tokens = region.split("-");
   const end = (parseInt(tokens[1]) - 1).toString();

--- a/lib/fetch_variant_ld.js
+++ b/lib/fetch_variant_ld.js
@@ -125,10 +125,18 @@ async function getVariantsScore(request, variants, assembly) {
     return acc;
   }, new Set());
   const regions = Array.from(regionsSet);
-  const regionsParm = regions.join(" ");
-  const query = `${API_SCORE}regions=${regionsParm}&genome=${assembly}`;
-  const scores = await request.getObjectByUrl(query);
-  const scoresFormatted = scores.variants.reduce((acc, cur) => {
+  const batchNum = 50;
+  let total = [];
+  do {
+    const regionsParm = regions
+      .splice(0, regions.length > batchNum ? batchNum : regions.length)
+      .join(" ");
+    const query = `${API_SCORE}regions=${regionsParm}&genome=${assembly}`;
+    const scores = await request.getObjectByUrl(query);
+    total = total.concat(scores.variants);
+  } while (regions.length > 0);
+
+  const scoresFormatted = total.reduce((acc, cur) => {
     acc[`${cur.chrom}:${cur.start}-${cur.end}`] = cur;
     return acc;
   }, {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -6980,9 +6980,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001517",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
+      "version": "1.0.30001578",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001578.tgz",
+      "integrity": "sha512-J/jkFgsQ3NEl4w2lCoM9ZPxrD+FoBNJ7uJUpGVjIg/j0OwJosWM36EPDv+Yyi0V4twBk9pPmlFS+PLykgEvUmg==",
       "funding": [
         {
           "type": "opencollective",

--- a/pages/api/variant-ld.js
+++ b/pages/api/variant-ld.js
@@ -1,0 +1,21 @@
+import FetchRequest from "../../lib/fetch-request";
+import fetchVariantLD from "../../lib/fetch_variant_ld";
+
+/**
+ * This api is used for querying variants in variant LD data and score them for any given single variant.
+ * @returns {arry} data in json format. The data returned will include
+ * a list of variants with their score info.
+ */
+export default async function handler(req, res) {
+  const request = new FetchRequest();
+  const region = req.query.regions;
+  const assembly = req.query.genome;
+  const r2 = req.query.r2;
+  const ancestry = req.query.ancestry;
+  try {
+    const data = await fetchVariantLD(request, region, assembly, r2, ancestry);
+    res.status(200).json(data);
+  } catch (error) {
+    res.status(400).json(error);
+  }
+}

--- a/pages/query.js
+++ b/pages/query.js
@@ -193,7 +193,6 @@ export default function Query() {
                 id="r2"
                 name="r2"
                 rows="1"
-                cols="5"
                 placeholder="Enter a value between 0.80  and 0.99, default to 0.8"
                 onChange={(e) => setR2(e.target.value)}
               ></textarea>

--- a/pages/query.js
+++ b/pages/query.js
@@ -23,7 +23,10 @@ export default function Query() {
   const [isOpen, setIsOpen] = useState(false);
   const [maf, setMaf] = useState("1.1");
   const [assembly, setAssembly] = useState("GRCh38");
+  const [ancestry, setAncestry] = useState("");
+  const [r2, setR2] = useState("0.8");
   const [textInput, setTextInput] = useState("");
+  const [includeVariantsInLD, setIncludeVariantsInLD] = useState(true);
 
   // Handles the submit event on form submit.
   async function handleSubmit(event) {
@@ -56,6 +59,13 @@ export default function Query() {
                 genome: assembly,
                 maf,
               };
+        if (includeVariantsInLD) {
+          query.r2 = r2;
+          query.ld = true;
+          if (ancestry) {
+            query.ancestry = ancestry;
+          }
+        }
         Router.push({
           pathname: "/summary",
           query,
@@ -133,6 +143,59 @@ export default function Query() {
                 placeholder="Enter rsID(s) OR region(s), one per line. For example: rs75982468, chr12:69360231-69360232."
                 value={textInput}
                 onChange={(e) => setTextInput(e.target.value)}
+              ></textarea>
+            </div>
+          </div>
+          <div className="flex items-center mb-6">
+            <div className="w-1/3">
+              <DataItemLabel htmlFor="include">
+                Include variants in LD
+              </DataItemLabel>
+            </div>
+            <div className="w-2/3">
+              <input
+                className="mr-1"
+                type="checkbox"
+                checked={includeVariantsInLD}
+                onChange={(e) => setIncludeVariantsInLD(e.target.checked)}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center mb-6">
+            <div className="w-1/3">
+              <DataItemLabel htmlFor="ancestry">Ancestry</DataItemLabel>
+            </div>
+            <div className="w-2/3">
+              <select
+                className={inputClassName}
+                name="ancestry"
+                value={ancestry}
+                onChange={(e) => setAncestry(e.target.value)}
+              >
+                <option value="">Select one...</option>
+
+                <option value="EAS">EAS</option>
+                <option value="EUR">EUR</option>
+                <option value="AFR">AFR</option>
+                <option value="SAS">SAS</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="flex items-center mb-6">
+            <div className="w-1/3">
+              <DataItemLabel htmlFor="r2">R2</DataItemLabel>
+            </div>
+            <div className="w-2/3">
+              <textarea
+                className={inputClassName}
+                id="r2"
+                name="r2"
+                rows="1"
+                cols="5"
+                placeholder="Enter a value between 0.80  and 0.99, default to 0.8"
+                onChange={(e) => setR2(e.target.value)}
               ></textarea>
             </div>
           </div>

--- a/pages/search.js
+++ b/pages/search.js
@@ -288,13 +288,16 @@ export async function getServerSideProps({ query }) {
     if (data.query_coordinates.length === 1) {
       motifDocList = await fetchMotifDoc(request, data["@graph"]);
       if (query.ld) {
-        variantLD = await fetchVariantLD(
+        const response = await fetchVariantLD(
           request,
           data.query_coordinates[0],
           data.assembly,
           query.r2,
           query.ancestry
         );
+        if (Array.isArray(response)) {
+          variantLD = response;
+        }
       }
     }
 

--- a/pages/search.js
+++ b/pages/search.js
@@ -184,14 +184,6 @@ export default function Search({ data, motifDocList, variantLD, queryString }) {
                 ></ScoreDataItem>
               </ScoreDataArea>
             </DataPanel>
-            {variantLD.length > 0 && (
-              <>
-                <DataAreaTitle>Variant LD Table</DataAreaTitle>
-                <DataPanel>
-                  <VariantLDTable data={variantLD} />
-                </DataPanel>
-              </>
-            )}
             {Object.keys(hitSnps).length > 0 && (
               <>
                 <DataAreaTitle>
@@ -240,6 +232,15 @@ export default function Search({ data, motifDocList, variantLD, queryString }) {
 
             {data.nearby_snps?.length > 0 ? <SnpsDiagram data={data} /> : null}
             <div id="container"></div>
+
+            {variantLD.length > 0 && (
+              <>
+                <DataAreaTitle>Variant LD Table</DataAreaTitle>
+                <DataPanel>
+                  <VariantLDTable data={variantLD} />
+                </DataPanel>
+              </>
+            )}
           </>
         )}
         <ChipDataView chipData={chipData}></ChipDataView>
@@ -286,11 +287,15 @@ export async function getServerSideProps({ query }) {
     let variantLD = [];
     if (data.query_coordinates.length === 1) {
       motifDocList = await fetchMotifDoc(request, data["@graph"]);
-      variantLD = await fetchVariantLD(
-        request,
-        data.query_coordinates[0],
-        data.assembly
-      );
+      if (query.ld) {
+        variantLD = await fetchVariantLD(
+          request,
+          data.query_coordinates[0],
+          data.assembly,
+          query.r2,
+          query.ancestry
+        );
+      }
     }
 
     const breadcrumbs = [

--- a/pages/summary.js
+++ b/pages/summary.js
@@ -74,7 +74,7 @@ export async function getServerSideProps({ query }) {
     if (data["@type"][0] === "search") {
       return {
         redirect: {
-          destination: `${data["@id"]}`,
+          destination: `/search?${queryString}`,
           permanent: true,
         },
       };


### PR DESCRIPTION
This ticket focus on the backend: getting the variant ld data in catalog for a given SNP in regulome. 

We first get the variants in catalog for the given region, then get variants in variant LD data for each variants, then go back to GDS to get score for all those variants in variant LD data.

When query, we will only query variant LD data if one single variant is returned from GDS, which means that we only query variant LD data at search page, not summary page.

variant LD data now shown in variant LD table. This may change as we haven't decided how to visualize the data.