### PR TITLE
REGD-150-chromatin2 add tissue score scale box in the chromatin biosample facet table

### DIFF
--- a/components/chromatin-biosample-facets.js
+++ b/components/chromatin-biosample-facets.js
@@ -30,8 +30,8 @@ export default function ChromatinBiosampleFacets({
           const isSelected = biosampleFilters.includes(facet.biosample);
           return (
             <div key={key}>
-              <div className="grid grid-cols-4">
-                <div className="col-span-3">
+              <div className="grid grid-cols-10">
+                <div className="col-span-6">
                   <button
                     className={`text-sm hover:bg-highlight
                     ${isSelected ? "border-solid border-2 border-brand" : ""}`}
@@ -43,8 +43,20 @@ export default function ChromatinBiosampleFacets({
                     </div>
                   </button>
                 </div>
-                <div className="col-span-1 pl-2">
+                <div className="col-span-3 pl-2">
                   <BiosampleStateBar states={facet.states} />
+                </div>
+                <div className="col-span-1 flex">
+                  {facet.tissue_specific_score && (
+                    <>
+                      <div
+                        className={`box-content h-3 w-3 p-1 ${facet.tissue_specific_score_color}`}
+                      ></div>
+                      <span className="pl-2">
+                        {facet.tissue_specific_score.toFixed(2)}
+                      </span>
+                    </>
+                  )}
                 </div>
               </div>
             </div>

--- a/lib/chromatin-data.js
+++ b/lib/chromatin-data.js
@@ -298,6 +298,8 @@ export function getChromatinData(data) {
       dataset.dataset = filteredData[i].dataset;
       dataset.file = filteredData[i].file;
       dataset.tissue_specific_score = filteredData[i].tissue_specific_score;
+      dataset.tissue_specific_score_color =
+        filteredData[i].tissue_specific_score_color;
       chromatinData[i] = dataset;
     }
   }
@@ -401,6 +403,8 @@ export function getBiosampleFacets(data, assembly) {
           biosample,
           organ: dataset.organ,
           states: order.reduce((acc, curr) => ((acc[curr] = 0), acc), {}),
+          tissue_specific_score: dataset.tissue_specific_score,
+          tissue_specific_score_color: dataset.tissue_specific_score_color,
         };
         accumulator[biosample].states[state] = 1;
       }

--- a/lib/tissue-specific-score.js
+++ b/lib/tissue-specific-score.js
@@ -96,6 +96,8 @@ export function getDataWithTissueScore(data, normalizedTissueSpecificScore) {
           dataset.tissue_specific_score = maxScore;
           dataset.normalized_tissue_specific_score =
             normalizedTissueSpecificScore[organWithMaxScore][1];
+          dataset.tissue_specific_score_color =
+            TissueScoreTailwindColor[dataset.normalized_tissue_specific_score];
         }
       }
     });


### PR DESCRIPTION
Ben asked to also add a new column for  tissue specific score scale box at the end of each row in the chromatin data biosample facet table. 