### PR TITLE
REGD-135-dark-mode2

### DIFF
--- a/components/nearby-diagram.js
+++ b/components/nearby-diagram.js
@@ -333,7 +333,6 @@ export default function NearbyDiagram({
                 y1={0}
                 y2={zoomInIconPositionForSequence}
                 stroke="#e9d66b"
-                strokeDasharray="40,8"
                 strokeWidth={3}
                 opacity="0.8"
               />
@@ -345,7 +344,6 @@ export default function NearbyDiagram({
                 y1={sequencePositionY}
                 y2={viewBoxHeight}
                 stroke="#e9d66b"
-                strokeDasharray="40,8"
                 strokeWidth={baseWidth}
                 opacity="0.5"
               />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -271,6 +271,7 @@
  */
 .dark {
   --color-background: #111827;
+  --color-brand: #69ab5a;
   --color-brand-accent: #444444;
   --color-brand-highlight: #860f2d;
   --color-data-background: #0b0f19;
@@ -288,7 +289,7 @@
   --color-button-secondary-border: #36582e;
   --color-button-selected-border: #36582e;
   --color-button-warning-border: #c93638;
-  --color-button-secondary-label: #36582e;
+  --color-button-secondary-label: #69ab5a;
 
   --color-button-primary-background-disabled: #3e4864;
   --color-button-warning-background-disabled: #6b2f30;


### PR DESCRIPTION
Two updates based on QA comment:
1. change the dashed line in nearby drawing to solid line
2. Use a brighter tint of the same hue for the text and border of the button for dark mode.