### PR TITLE
REGD-196-coordinates

### DIFF
--- a/components/nearby-diagram.js
+++ b/components/nearby-diagram.js
@@ -319,6 +319,40 @@ export default function NearbyDiagram({
   const viewBoxHeight =
     motifPositionY + motifsList.length * geneUnitHeight + blankHeight * 2;
 
+  function getGeneScaleLabel(
+    index,
+    tickWidth,
+    scaleForGene,
+    geneScaleStartTick
+  ) {
+    const num = Math.floor(
+      (index * tickWidth) / scaleForGene + geneScaleStartTick
+    );
+    return num >= 0 ? num : "";
+  }
+
+  function getVariantScaleLabel(
+    index,
+    tickWidth,
+    scaleForVariantInLd,
+    offsetForVariantInLd
+  ) {
+    const num = Math.floor(
+      (index * tickWidth) / scaleForVariantInLd + offsetForVariantInLd
+    );
+    return num >= 0 ? num : "";
+  }
+
+  function getSequenceScaleLabel(
+    index,
+    tickWidth,
+    baseWidth,
+    offsetXForVariant
+  ) {
+    const num = Math.floor((index * tickWidth) / baseWidth + offsetXForVariant);
+    return num >= 0 ? num : "";
+  }
+
   return (
     <>
       <DataAreaTitle>Variant Nearby</DataAreaTitle>
@@ -382,8 +416,11 @@ export default function NearbyDiagram({
                       y={scaleForGenePositionY - tickHeight - 5}
                       textAnchor="middle"
                     >
-                      {Math.floor(
-                        (index * tickWidth) / scaleForGene + geneScaleStartTick
+                      {getGeneScaleLabel(
+                        index,
+                        tickWidth,
+                        scaleForGene,
+                        geneScaleStartTick
                       )}
                     </text>
                   </g>
@@ -521,9 +558,11 @@ export default function NearbyDiagram({
                               y={scaleForVariantsInLdPositionY - tickHeight - 5}
                               textAnchor="middle"
                             >
-                              {Math.floor(
-                                (index * tickWidth) / scaleForVariantInLd +
-                                  offsetForVariantInLd
+                              {getVariantScaleLabel(
+                                index,
+                                tickWidth,
+                                scaleForVariantInLd,
+                                offsetForVariantInLd
                               )}
                             </text>
                           </g>
@@ -617,8 +656,11 @@ export default function NearbyDiagram({
                       y={scaleForSequencePositionY - tickHeight - 5}
                       textAnchor="middle"
                     >
-                      {Math.floor(
-                        (index * tickWidth) / baseWidth + offsetXForVariant
+                      {getSequenceScaleLabel(
+                        index,
+                        tickWidth,
+                        baseWidth,
+                        offsetXForVariant
                       )}
                     </text>
                   </g>

--- a/components/summary-table.js
+++ b/components/summary-table.js
@@ -38,7 +38,7 @@ const summaryColumnsGRCh38 = [
   {
     id: "rsids",
     title: "dbSNP IDs",
-    display: ({ source }) => `${source.rsids.join(", ")}`,
+    display: ({ source }) => `${source.rsids ? source.rsids.join(", ") : ""}`,
   },
   {
     id: "spdi",
@@ -116,7 +116,7 @@ const summaryColumnsHg19 = [
   {
     id: "rsids",
     title: "dbSNP IDs",
-    display: ({ source }) => `${source.rsids.join(", ")}`,
+    display: ({ source }) => `${source.rsids ? source.rsids.join(", ") : ""}`,
   },
   {
     id: "rank",

--- a/components/variant-summary.js
+++ b/components/variant-summary.js
@@ -165,7 +165,7 @@ export default function VariantSummary({
                     <DataItemValue>{data.variants[0].alt}</DataItemValue>
                   </>
                 )}
-                {data.variants[0].rsids.length > 0 && (
+                {data.variants[0].rsids?.length > 0 && (
                   <>
                     <DataItemLabel>rsID</DataItemLabel>
                     <DataItemValue>

--- a/lib/fetch-nearby.js
+++ b/lib/fetch-nearby.js
@@ -30,15 +30,27 @@ export default async function fetchNearby(request, region, assembly) {
       displayStart -= 1000;
       displayEnd += 1000;
     } else {
-      displayStart = genes[0].end - 2000;
-      displayEnd = genes[1].start + 2000;
+      if (genes.length > 1) {
+        displayStart = genes[0].end - 2000;
+        displayEnd = genes[1].start + 2000;
+      } else {
+        const regionStart = parseInt(region.split(":")[1].split("-")[0]);
+        if (regionStart < genes[0].start) {
+          displayStart = regionStart - 2000;
+          // if (displayStart < 0) displayStart = 0;
+
+          displayEnd = genes[0].end + 2000;
+        } else {
+          displayStart = genes[0].start - 2000;
+          displayEnd = regionStart + 2000;
+        }
+      }
     }
 
     const displayRegion = `${genes[0].chr}:${displayStart}-${displayEnd}`;
-    const regulatoryRegions = await getRegulatoryRegions(
-      request,
-      displayRegion
-    );
+    const queryRegion =
+      displayStart >= 0 ? displayRegion : `${genes[0].chr}:0-${displayEnd}`;
+    const regulatoryRegions = await getRegulatoryRegions(request, queryRegion);
     if (ERRORS.includes(regulatoryRegions.code)) {
       return regulatoryRegions;
     }

--- a/lib/fetch-nearby.js
+++ b/lib/fetch-nearby.js
@@ -1,4 +1,8 @@
 import { API_URL_GENE, API_URL_REGULATORY_REGION, ERRORS } from "./constants";
+
+const CODING_REGION_EXPAND = 1000;
+const NON_CODING_REGION_EXPAND = 2000;
+
 /**
  * This function fetchs data from IGVF catalog, which is used for variant nearby drawing.
  * The data we need for the given region are: the coordinates of the display region,
@@ -27,20 +31,20 @@ export default async function fetchNearby(request, region, assembly) {
         if (genes[i].start < displayStart) displayStart = genes[i].start;
         else if (genes[i].end > displayEnd) displayEnd = genes[i].end;
       }
-      displayStart -= 1000;
-      displayEnd += 1000;
+      displayStart -= CODING_REGION_EXPAND;
+      displayEnd += CODING_REGION_EXPAND;
     } else {
       if (genes.length > 1) {
-        displayStart = genes[0].end - 2000;
-        displayEnd = genes[1].start + 2000;
+        displayStart = genes[0].end - NON_CODING_REGION_EXPAND;
+        displayEnd = genes[1].start + NON_CODING_REGION_EXPAND;
       } else {
         const regionStart = parseInt(region.split(":")[1].split("-")[0]);
         if (regionStart < genes[0].start) {
-          displayStart = regionStart - 2000;
-          displayEnd = genes[0].end + 2000;
+          displayStart = regionStart - NON_CODING_REGION_EXPAND;
+          displayEnd = genes[0].end + NON_CODING_REGION_EXPAND;
         } else {
-          displayStart = genes[0].start - 2000;
-          displayEnd = regionStart + 2000;
+          displayStart = genes[0].start - NON_CODING_REGION_EXPAND;
+          displayEnd = regionStart + NON_CODING_REGION_EXPAND;
         }
       }
     }

--- a/lib/fetch-nearby.js
+++ b/lib/fetch-nearby.js
@@ -37,8 +37,6 @@ export default async function fetchNearby(request, region, assembly) {
         const regionStart = parseInt(region.split(":")[1].split("-")[0]);
         if (regionStart < genes[0].start) {
           displayStart = regionStart - 2000;
-          // if (displayStart < 0) displayStart = 0;
-
           displayEnd = genes[0].end + 2000;
         } else {
           displayStart = genes[0].start - 2000;

--- a/pages/search.js
+++ b/pages/search.js
@@ -255,7 +255,9 @@ export async function getServerSideProps({ query }) {
         pageContext: {
           title: data.variants[0].spdi
             ? `${data.variants[0].spdi} (${data.regulome_score.probability})`
-            : `${data.query_coordinates[0]} (${data.regulome_score.probability})`,
+            : `${data.query_coordinates[0]} ${
+                data.regulome_score ? data.regulome_score.probability : ""
+              }`,
         },
         queryString,
       },


### PR DESCRIPTION
fix several bugs here:
1. If the variant is not in gene coding regions, there are cases that it may not return gens on both sides. Because the variant can be at the front or end of chromosome. Need to update the function for calculating display region.
2. for fields that is not required, need to check it first before getting the value
3. For the nearby diagram, don't show the tick label if it is negative.